### PR TITLE
Set upper bounds to prevent embed overflow

### DIFF
--- a/commands/log.js
+++ b/commands/log.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
-const { getLogEmbed } = require("./../logHandler.js");
+const { getLogEmbeds } = require("./../logHandler.js");
 const { checkTransactionsChannel } = require("./../permissionHandler.js");
 
 let l = {};
@@ -18,7 +18,7 @@ module.exports = {
       interaction.guildId
     );
     if (!validChannel) {
-      interaction.editReply({ embeds: [await getLogEmbed(interaction.guild)] });
+      interaction.editReply({ embeds: await getLogEmbeds(interaction.guild) });
     } else {
       interaction.editReply({
         embeds: [

--- a/commands/owe.js
+++ b/commands/owe.js
@@ -6,6 +6,7 @@ const {
   checkValidUser,
   checkTransactionsChannel,
 } = require("./../permissionHandler.js");
+const { MAX_DESCRIPTION, MAX_COST } = require("./../constants.js");
 
 const StatusEnum = Object.freeze({
   WORKING: 1,
@@ -23,7 +24,7 @@ module.exports = {
     .addNumberOption((option) =>
       option
         .setName("cost")
-        .setDescription("The total value owed")
+        .setDescription(`The total value owed [$0 > x > $${MAX_COST}]`)
         .setRequired(true)
     )
     .addUserOption((option) =>
@@ -35,7 +36,9 @@ module.exports = {
     .addStringOption((option) =>
       option
         .setName("description")
-        .setDescription("The description of the transaction")
+        .setDescription(
+          `The description of the transaction [<${MAX_DESCRIPTION} chars]`
+        )
         .setRequired(false)
     ),
   async execute(interaction) {
@@ -45,6 +48,7 @@ module.exports = {
     const cost = interaction.options.getNumber("cost");
     const user = interaction.options.getUser("user");
     const description = interaction.options.getString("description");
+
     let validUser = await checkValidUser(interaction);
     if (validUser) {
       let validChannel = await checkTransactionsChannel(
@@ -57,6 +61,22 @@ module.exports = {
             embeds: [
               {
                 description: `Invalid command usage: the value submitted must be a positive value.`,
+              },
+            ],
+          });
+        } else if (cost >= MAX_COST) {
+          interaction.editReply({
+            embeds: [
+              {
+                description: `Invalid command usage: the value submitted must be less than ${MAX_COST}.`,
+              },
+            ],
+          });
+        } else if (description && description.length > MAX_DESCRIPTION) {
+          interaction.editReply({
+            embeds: [
+              {
+                description: `Invalid command usage: the description submitted must be <${MAX_DESCRIPTION} characters long.`,
               },
             ],
           });

--- a/commands/paid.js
+++ b/commands/paid.js
@@ -6,6 +6,7 @@ const {
   checkValidUser,
   checkTransactionsChannel,
 } = require("./../permissionHandler.js");
+const { MAX_COST } = require("./../constants.js");
 
 const StatusEnum = Object.freeze({
   WORKING: 1,
@@ -23,7 +24,7 @@ module.exports = {
     .addNumberOption((option) =>
       option
         .setName("cost")
-        .setDescription("The total value being paid")
+        .setDescription(`The total value being paid [$0 > x > $${MAX_COST}]`)
         .setRequired(true)
     )
     .addUserOption((option) =>
@@ -50,6 +51,14 @@ module.exports = {
             embeds: [
               {
                 description: `Invalid command usage: the value submitted must be a positive value.`,
+              },
+            ],
+          });
+        } else if (cost >= MAX_COST) {
+          interaction.editReply({
+            embeds: [
+              {
+                description: `Invalid command usage: the value submitted must be less than ${MAX_COST}.`,
               },
             ],
           });

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,6 @@
+module.exports = {
+  MAX_USERS = 12,
+  MAX_DESCRIPTION = 100,
+  MAX_COST = 1000,
+  MAX_OWE = 10000
+};

--- a/slashCommands.js
+++ b/slashCommands.js
@@ -9,8 +9,8 @@ const commandFiles = fs
   .filter((file) => file.endsWith(".js"));
 
 // Place your client and guild ids here
-const clientId = "bot-id-here";
-const guildId = "guild-id-here";
+const clientId = "872670044595826698";
+const guildId = "839665867461361720";
 
 for (const file of commandFiles) {
   const command = require(`./commands/${file}`);


### PR DESCRIPTION
Set upper bound limits on number of registered users, description lengths, and transaction costs. Updated log to add on additional embeds if too many users. Updated history to display fewer entries if too many users.